### PR TITLE
Support for Singly Linked List Abstract Data Types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# data_structures
-Some helpful code that can help when doing leetcode and similar problem practices. 
+# Data Structures
+
+## Available In data_structures
+### Nodes
+- You will find a generic the `BinarySearchTreeNode` class
+-- Use this to annotate your code and to understand how the data can be linked in memeory (via reference, etc)
+- You will find generic the `AVLTreeNode` class
+-- likewise, use this to annotate your code and to understand how data can be linked in memory 
+You can also use these classes to play around and build your own data structure. 
+
+### Data Structures
+* You will find an `AVL` implementation, which uses `AVLTreeNode` under the hood. 
+  * This class can be printed.
+
+  ```
+  # for example
+  print(AVL(x for x in range(12))) 
+
+  # The following will be printed
+  #     ┌─11
+  #   ┌─10
+  #   │ └─None
+  # ┌─9
+  # │ └─8
+  # 7
+  # │   ┌─6
+  # │ ┌─5
+  # │ │ └─4
+  # └─3
+  #   │ ┌─2
+  #   └─1
+  #     └─0
+
+  ```
+
+* You will also find an implementation for `BinarySearchTree`
+  * can also be printed liked `AVL`
+
+
+## About the code
+The code provided here is not meant to solve any problem for you. It is meant to give you the tools to understand and play around with different solutions for programming problems. 
+
+
+For example, given a problem like, [Validate Binary Search Tree](https://leetcode.com/problems/validate-binary-search-tree/description/), I can use an input list such as `[2,1,3]` and construct a BST on my local environment and play around with it.
+```
+from data_structures import BinarySearchTree as Tree
+from data_structures.nodes import BinarySearchTreeNode as Node
+
+root = Tree.from_mapped_list([2,1,3]).root
+def is_valid_BST(root: Node):
+    ...
+is_valid_BST(root)
+```
+after this, I can use my debugging tool to see how the `is_valid_BST` algorithm work. Moreover, I can play around with different inputs to test my assumptions. 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Available In data_structures
 ### Nodes
-- You will find a generic the `BinarySearchTreeNode` class
--- Use this to annotate your code and to understand how the data can be linked in memeory (via reference, etc)
-- You will find generic the `AVLTreeNode` class
--- likewise, use this to annotate your code and to understand how data can be linked in memory 
+* You will find a generic the `BinarySearchTreeNode` class
+  * Use this to annotate your code and to understand how the data can be linked in memeory (via reference, etc)
+* You will find generic the `AVLTreeNode` class
+  * likewise, use this to annotate your code and to understand how data can be linked in memory 
 You can also use these classes to play around and build your own data structure. 
 
 ### Data Structures

--- a/data_structures/__init__.py
+++ b/data_structures/__init__.py
@@ -1,4 +1,4 @@
-from adelson_velsky_landis import AVL
-from binary_search_tree import BinarySearchTree
+from .adelson_velsky_landis import AVL
+from .binary_search_tree import BinarySearchTree
 
 __all__ = ["BinarySearchTree", "AVL"]

--- a/data_structures/__init__.py
+++ b/data_structures/__init__.py
@@ -1,0 +1,4 @@
+from adelson_velsky_landis import AVL
+from binary_search_tree import BinarySearchTree
+
+__all__ = ["BinarySearchTree", "AVL"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -145,7 +145,10 @@ class AVLTreeNode(Generic[CT]):
 
 
 class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
-    pass
+    def __new__(
+        cls, value: T, next: Optional[SinglyLinkedListNode[T]] = None
+    ) -> SinglyLinkedListNode[T]:
+        return tuple.__new__(cls, (value, next))
 
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -164,5 +164,8 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
     def val(self, value: T) -> None:
         self.value = value
 
+    def __iter__(self) -> Iterator[Union[T, Optional[SinglyLinkedListNode[T]]]]:
+        yield from (self.value, self.next)
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -144,4 +144,8 @@ class AVLTreeNode(Generic[CT]):
         yield from (self.value, self.left, self.right)
 
 
-__all__ = ["BinarySearchTreeNode", "AVLTreeNode"]
+class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
+    pass
+
+
+__all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -178,5 +178,8 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.val!r})"
 
+    def __str__(self) -> str:
+        return f"{str(self.value)}"
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -175,5 +175,8 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
         except TypeError:
             raise NotImplemented
 
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.val!r})"
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -167,5 +167,13 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
     def __iter__(self) -> Iterator[Union[T, Optional[SinglyLinkedListNode[T]]]]:
         yield from (self.value, self.next)
 
+    def __eq__(self, __o: Union[T, SinglyLinkedListNode[T]]) -> bool:
+        try:
+            if isinstance(__o, SinglyLinkedListNode):
+                return self.value == __o.value
+            return self.value == __o
+        except TypeError:
+            raise NotImplemented
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -150,5 +150,11 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
     ) -> SinglyLinkedListNode[T]:
         return tuple.__new__(cls, (value, next))
 
+    def __init__(
+        self, value: T, next: Optional[SinglyLinkedListNode[T]] = None
+    ) -> None:
+        self.value = value
+        self.next = next
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]

--- a/data_structures/nodes.py
+++ b/data_structures/nodes.py
@@ -156,5 +156,13 @@ class SinglyLinkedListNode(tuple[T, "SinglyLinkedListNode[T]"]):
         self.value = value
         self.next = next
 
+    @property
+    def val(self) -> T:
+        return self.value
+
+    @val.setter
+    def val(self, value: T) -> None:
+        self.value = value
+
 
 __all__ = ["BinarySearchTreeNode", "AVLTreeNode", "SinglyLinkedListNode"]


### PR DESCRIPTION
close #8 

This update brings support for Singly Linked List Abstract Data Types as requested in [this issue](#8).
The following properties are present;
* val
* value
* next

the following dunders have been overloaded
* iter 
* eq
* repr
* str 